### PR TITLE
Properly start and exit the proxy server before running the benchmarks

### DIFF
--- a/slave/benchmarks.py
+++ b/slave/benchmarks.py
@@ -1,15 +1,14 @@
+import benchmarks_local
+import benchmarks_remote
+import benchmarks_shell
 
 def getBenchmark(benchmark):
     section, name = benchmark.split(".")
     if section == "local":
-        import benchmarks_local
         return benchmarks_local.getBenchmark(name)
     elif section == "remote":
-        import benchmarks_remote
         return benchmarks_remote.getBenchmark(name)
     elif section == "shell":
-        import benchmarks_shell
         return benchmarks_shell.getBenchmark(name)
     else:
         raise Exception("Unknown benchmark type")
-

--- a/slave/benchmarks_local.py
+++ b/slave/benchmarks_local.py
@@ -125,10 +125,3 @@ def getBenchmark(name):
     if name == "unity-webgl":
         return UnityWebGL()
     raise Exception("Unknown benchmark")
-
-# Test if server is running and start server if needed.
-s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-result = s.connect_ex(("localhost", 8000))
-s.close()
-if result > 0:
-    subprocess.Popen(["python", "server.py"])

--- a/slave/benchmarks_remote.py
+++ b/slave/benchmarks_remote.py
@@ -463,10 +463,3 @@ def getBenchmark(name):
         if name == b.name():
             return b()
     raise Exception("Unknown benchmark")
-
-# Test if server is running and start server if needed.
-s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-result = s.connect_ex(("localhost", 8000))
-s.close()
-if result > 0:
-    subprocess.Popen(["python", "server.py"])

--- a/slave/server.py
+++ b/slave/server.py
@@ -56,7 +56,7 @@ class FakeHandler(SimpleHTTPRequestHandler):
         if self.path.startswith("/submit"):
             return self.captureResults(query)
         else:
-            return self.retrieveOffline();
+            return self.retrieveOffline()
 
     def retrieveOffline(self):
         path = self.translate_path(self.path)
@@ -106,10 +106,16 @@ class FakeHandler(SimpleHTTPRequestHandler):
 
     def captureResults(self, query):
         queryParsed = urlparse.parse_qs(query)
-        fp = open("slave/results", "w");
-        fp.write(queryParsed["results"][0]);
+        fp = open("slave/results", "w")
+        fp.write(queryParsed["results"][0])
         fp.close()
-        return False
+
+        content = "Results successfully captured!"
+        self.send_response(200)
+        self.send_header("Content-Length", len(content))
+        self.end_headers()
+        self.wfile.write(bytes(content))
+        return True
 
     def translatePath(self, old_host, old_path):
         global translates, benchmarks


### PR DESCRIPTION
This removes the hacky starting of the proxy server, by running it before starting any benchmark and closing it properly in all the cases. It bite me a few times that a proxy server was running in the background while the execute script had terminated, showing cached versions of benchmarks I was trying to update.

@h4writer In your own time, would you please have a look? This works fine locally, fwiw.