### PR TITLE
Mac downloads to support TaskCluster and Buildbot bridge

### DIFF
--- a/slave/download.py
+++ b/slave/download.py
@@ -29,7 +29,8 @@ def download_from_url(url):
         url.startswith("https://inbound-archive.pub.build.mozilla.org")):
         return ArchiveMozillaDownloader(url)
 
-    if url.startswith("https://queue.taskcluster.net/v1/task/"):
+    if (url.startswith("https://queue.taskcluster.net/v1/task/") or
+        url.startswith("https://public-artifacts.taskcluster.net")):
         return TreeherderDownloader(url)
 
     if url.startswith("http://commondatastorage.googleapis.com"):


### PR DESCRIPTION
Recently, we made TaskCluster cross-compiled Mac builds on trunk trees
into tier 1 platforms. These replaced the Buildbot builds.

On older release branches we also made a change where a Buildbot build
is driven by TaskCluster via the Buildbot bridge. The Buildbot bridge
schedules normal Buildbot jobs. The Buildbot bridge also sets a
property called 'upload_to_task_id'. This task id is used to create
a TaskCluster task and upload there the build artifacts. Using this
will help us not have to deal with archive.mozilla.org at all.