### PR TITLE
Test downloads more effectively

### DIFF
--- a/slave/download.py
+++ b/slave/download.py
@@ -67,7 +67,7 @@ class Downloader(object):
         self.folder = "./"
 
     def valid(self):
-        return self.getfilename() != None
+        return self.get_filename() != None
 
     def set_output_folder(self, folder):
         if not folder.endswith("/"):
@@ -77,7 +77,7 @@ class Downloader(object):
     def download(self):
         self.create_output_folder()
 
-        filename = self.getfilename()
+        filename = self.get_filename()
         assert filename
         self.retrieve(filename)
         self.extract(filename)
@@ -112,11 +112,11 @@ class TreeherderDownloader(Downloader):
         self.url = "/".join(url.split("/")[:-1])+"/"
         self.filename = url.split("/")[-1]
 
-    def getfilename(self):
+    def get_filename(self):
         return self.filename
 
     def retrieve_info(self):
-        infoname = self.getinfoname()
+        infoname = self.get_info_filename()
 
         raw_info = utils.fetch_json(self.url + infoname)
 
@@ -124,13 +124,13 @@ class TreeherderDownloader(Downloader):
         info["revision"] = raw_info["moz_source_stamp"]
         info["engine_type"] = "firefox"
         info["shell"] = False
-        info["binary"] = os.path.abspath(self.getbinary())
+        info["binary"] = os.path.abspath(self.get_binary())
         info["folder"] = os.path.abspath(self.folder)
 
         return info
 
-    def getinfoname(self):
-        filename = self.getfilename()
+    def get_info_filename(self):
+        filename = self.get_filename()
         try:
             filename = os.path.splitext(filename)[0]
             response = urllib2.urlopen(self.url + filename + ".json")
@@ -142,7 +142,7 @@ class TreeherderDownloader(Downloader):
 
         return filename + ".json"
 
-    def getbinary(self):
+    def get_binary(self):
         if os.path.exists(self.folder + "firefox/firefox.exe"):
             return self.folder + "firefox/firefox.exe"
         if os.path.exists(self.folder + "firefox/firefox"):
@@ -157,7 +157,7 @@ class TreeherderDownloader(Downloader):
 
 class ArchiveMozillaDownloader(Downloader):
 
-    def getfilename(self):
+    def get_filename(self):
         try:
             response = urllib2.urlopen(self.url)
             html = response.read()
@@ -167,18 +167,18 @@ class ArchiveMozillaDownloader(Downloader):
         possibles = re.findall(r'<a href=".*((firefox|fennec)-[a-zA-Z0-9._-]*)">', html)
         possibles = [possible[0] for possible in possibles]
 
-        filename = self.getUniqueFileName(possibles)
+        filename = self.get_unique_filename(possibles)
         if filename:
             return filename
 
-        filename = self.getPlatformFileName(possibles, platform.system(), platform.architecture()[0])
+        filename = self.get_platform_filename(possibles, platform.system(), platform.architecture()[0])
         if filename:
             return filename
 
         return None
 
     def retrieve_info(self):
-        infoname = self.getinfoname()
+        infoname = self.get_info_filename()
 
         response = urllib2.urlopen(self.url + infoname)
         raw_info = json.loads(response.read())
@@ -187,7 +187,7 @@ class ArchiveMozillaDownloader(Downloader):
         info["revision"] = raw_info["moz_source_stamp"]
         info["engine_type"] = "firefox"
         info["shell"] = False
-        info["binary"] = os.path.abspath(self.getbinary())
+        info["binary"] = os.path.abspath(self.get_binary())
         info["folder"] = os.path.abspath(self.folder)
 
         return info
@@ -213,13 +213,13 @@ class ArchiveMozillaDownloader(Downloader):
                 possibles2.append(possible)
         return possibles2
 
-    def getUniqueFileName(self, possibles):
+    def get_unique_filename(self, possibles):
         possibles = self._remove_extra_files(possibles)
         if len(possibles) != 1:
             return None
         return possibles[0]
 
-    def getPlatformFileName(self, possibles, platform, arch):
+    def get_platform_filename(self, possibles, platform, arch):
         possibles = self._remove_extra_files(possibles)
         if platform == "Darwin":
             possibles = [possible for possible in possibles if "mac" in possible]
@@ -242,8 +242,8 @@ class ArchiveMozillaDownloader(Downloader):
             return None
         return possibles[0]
 
-    def getinfoname(self):
-        filename = self.getfilename()
+    def get_info_filename(self):
+        filename = self.get_filename()
         try:
             filename = os.path.splitext(filename)[0]
             response = urllib2.urlopen(self.url + filename + ".json")
@@ -255,7 +255,7 @@ class ArchiveMozillaDownloader(Downloader):
 
         return filename + ".json"
 
-    def getbinary(self):
+    def get_binary(self):
         if os.path.exists(self.folder + "firefox/firefox.exe"):
             return self.folder + "firefox/firefox.exe"
         if os.path.exists(self.folder + "firefox/firefox"):
@@ -271,7 +271,7 @@ class ArchiveMozillaDownloader(Downloader):
 
 class GoogleAPISDownloader(Downloader):
 
-    def getfilename(self):
+    def get_filename(self):
         platform = self.url.split("/")[-3]
         if platform.startswith("Linux"):
             return "chrome-linux.zip"
@@ -283,7 +283,7 @@ class GoogleAPISDownloader(Downloader):
             return "chrome-android.zip"
         raise Exception("Unknown platform: " + platform)
 
-    def getbinary(self):
+    def get_binary(self):
         if os.path.exists(self.folder + "chrome-linux/chrome"):
             return self.folder + "chrome-linux/chrome"
         if os.path.exists(self.folder + "chrome-win32/chrome.exe"):
@@ -302,7 +302,7 @@ class GoogleAPISDownloader(Downloader):
         info["revision"] = cset
         info["engine_type"] = "chrome"
         info["shell"] = False
-        info["binary"] = os.path.abspath(self.getbinary())
+        info["binary"] = os.path.abspath(self.get_binary())
         info["folder"] = os.path.abspath(self.folder)
 
         return info
@@ -316,7 +316,7 @@ class BuildsWebkitDownloader(Downloader):
             self.url += "/"
         self.folder = "./"
 
-    def getfilename(self):
+    def get_filename(self):
         return self.file
 
     def retrieve_info(self):

--- a/slave/download.py
+++ b/slave/download.py
@@ -46,9 +46,9 @@ def download_from_url(url):
 
 def download_for_repo(config, repo, cset="latest", buildtype='opt'):
     print "Downloading for repository {}".format(repo, cset)
-    urlCreator = url_creator.getUrlCreator(config, repo)
+    creator = url_creator.get(config, repo)
 
-    urls = urlCreator.find(cset, buildtype=buildtype)
+    urls = creator.find(cset, buildtype=buildtype)
     for url in urls:
         print "trying: " + url
         downloader = download_from_url(url)

--- a/slave/url_creator.py
+++ b/slave/url_creator.py
@@ -16,7 +16,7 @@ class UrlCreator(object):
         if cset == 'latest':
             urls = self.latest(**kwargs)[0:5]
         else:
-            urls = self.urlForRevision(cset, **kwargs)
+            urls = self.url_for_revision(cset, **kwargs)
         return urls
 
 class ChromeUrlCreator(UrlCreator):
@@ -101,18 +101,18 @@ class MozillaUrlCreator(UrlCreator):
 
         revisions = [i["revision"] for i in data["results"]]
         for revision in revisions:
-            urls = self._urlForRevision(revision, buildtype)
+            urls = self._url_for_revision(revision, buildtype)
             if len(urls) == 1:
                 return [urls[0]]
 
         return []
 
-    def urlForRevision(self, cset, buildtype):
-        urls = self._urlForRevision(cset, buildtype)
+    def url_for_revision(self, cset, buildtype):
+        urls = self._url_for_revision(cset, buildtype)
         assert len(urls) == 1
         return urls
 
-    def _urlForRevision(self, cset, buildtype):
+    def _url_for_revision(self, cset, buildtype):
         assert buildtype in ('opt', 'debug', 'pgo'), \
             '{} is not a valid buildtype ("opt", "debug", "pgo").'.format(
                 buildtype
@@ -180,11 +180,11 @@ class MozillaUrlCreator(UrlCreator):
 
         return urls
 
-def getUrlCreator(config, name):
-    if "mozilla" in name:
-        return MozillaUrlCreator(config, name)
-    if "chrome" in name:
-        return ChromeUrlCreator(config, name)
-    if "webkit" in name:
-        return WebKitUrlCreator(config, name)
+def get(config, repo):
+    if "mozilla" in repo:
+        return MozillaUrlCreator(config, repo)
+    if "chrome" in repo:
+        return ChromeUrlCreator(config, repo)
+    if "webkit" in repo:
+        return WebKitUrlCreator(config, repo)
     raise Exception("Unknown vendor")

--- a/tests/test_url_creator.py
+++ b/tests/test_url_creator.py
@@ -1,27 +1,48 @@
+#!/usr/bin/env python2
+
 import sys
 sys.path.append("../slave")
 
 import url_creator
 
-creators = [
-    url_creator.getUrlCreator("mozilla-inbound"),
-    url_creator.getUrlCreator("mozilla-aurora"),
-    url_creator.getUrlCreator("mozilla-beta"),
-    url_creator.getUrlCreator("mozilla-central"),
-    url_creator.getUrlCreator("mozilla-release"),
-    url_creator.getUrlCreator("chrome"),
-    url_creator.getUrlCreator("webkit")
+repos = [
+    "mozilla-inbound",
+    "mozilla-central",
+    "mozilla-aurora",
+    # "mozilla-beta", # TODO no 32 bits
+    # "mozilla-release", # TODO no 32 bits
+    "chrome",
+    "webkit",
 ]
 
-# Test 1
-for creator in creators:
-    urls = creator.find()
+archs = [
+    '32bits',
+    '64bits'
+]
+
+for repo in repos:
+    for arch in archs:
+        print "Testing optimized download for {} on {}.".format(repo, arch)
+
+        urls = url_creator.get(arch, repo).find(buildtype='opt')
+        assert urls
+        assert len(urls) > 0
+
+        print "PASSED"
+        print ""
+
+for arch in archs:
+    print "Testing PGO download for mozilla-central on {}.".format(arch)
+    urls = url_creator.get(arch, "mozilla-central").find(buildtype='pgo')
     assert urls
     assert len(urls) > 0
+    print "PASSED"
+    print ""
 
-# Test 2
-creator = url_creator.getUrlCreator("mozilla-inbound")
-urls = creator.find("4a38ccb01816")
+print "Testing downloading a specific revision on mozilla-inbound."
+creator = url_creator.get("64-bits", "mozilla-inbound")
+urls = creator.find("dc98dc9e0725", buildtype='opt')
 assert urls
 assert len(urls) > 0
-
+print "PASSED"
+print ""


### PR DESCRIPTION
The following commits:
- change a few names to be more pythonic (with camel_casing)
- add more Mozilla downloads for release/beta, where the N symbol is sometimes used in place of the B/Bo symbols (and the filename in the url is `firefox-{VERSION_NUMBER}.{SOMETHING}.{PLATFORM}.zip` in this case)
- update the `url_creator` tests and add the ability to create URLs for another platform than the current one

@armenzg, can you have a look please? Thanks!