### PR TITLE
Issue 138 - Support for downloading nightly builds

### DIFF
--- a/slave/url_creator.py
+++ b/slave/url_creator.py
@@ -111,8 +111,8 @@ class MozillaUrlCreator(UrlCreator):
         return urls
 
     def _url_for_revision(self, cset, buildtype):
-        assert buildtype in ('opt', 'debug', 'pgo'), \
-            '{} is not a valid buildtype ("opt", "debug", "pgo").'.format(
+        assert buildtype in ('opt', 'pgo', 'nightly'), \
+            '{} is not a valid buildtype (opt, pgo, nightly).'.format(
                 buildtype
             )
 

--- a/tests/test_url_creator.py
+++ b/tests/test_url_creator.py
@@ -5,13 +5,13 @@ sys.path.append("../slave")
 
 import url_creator
 
-platforms = [
+PLATFORMS = [
     "Windows",
     "Linux",
     "Darwin"
 ]
 
-repos = [
+REPOS = [
     "mozilla-inbound",
     "mozilla-central",
     "mozilla-beta",
@@ -47,11 +47,34 @@ def skip(platform, repo, arch):
 
     return False
 
+
+def test_configuration(repo, platform, arch=None, buildtype=None):
+    print("Testing download for ({},{},{},{})".format(repo, platform, arch, buildtype))
+    assert platform in PLATFORMS
+    try:
+        urls = url_creator.get(arch, repo, platform).find(buildtype=buildtype)
+        assert len(urls) > 0
+        print "PASSED\n"
+        return []
+    except:
+        print "FAILED\n"
+        return (repo, platform, arch, buildtype)
+
+
 def main():
     failures = []
 
-    for repo in repos:
-        for platform in platforms:
+    configurations = [
+        ('mozilla-central', 'Windows', '64bit', 'nightly'),
+        ('mozilla-central', 'Windows', '32bit', 'nightly'),
+        ('mozilla-central', 'Darwin',  '64bit', 'nightly'),
+    ]
+
+    for c in configurations:
+        failures += test_configuration(*c)
+
+    for repo in REPOS:
+        for platform in PLATFORMS:
             for arch in archs:
                 if skip(platform, repo, arch):
                     continue


### PR DESCRIPTION
r? @bnjbvr 

I've tested this for macosx64, win32 and win64.
The change does not support Linux. This can come later.

FYI macosx64 builds are still downloading the Buildbot version.
https://bugzilla.mozilla.org/show_bug.cgi?id=1377114
When the bug gets fixed we will have to adjust which will also fix the Linux situation.