### PR TITLE
Bug 1390206 profile

### DIFF
--- a/slave/configs.py
+++ b/slave/configs.py
@@ -20,6 +20,7 @@ class Default(object):
             self.env_["JSGC_DISABLE_POISONING"] = "1"
             self.prefs_["dom.max_script_run_time"] = 0
             self.prefs_["javascript.options.asyncstack"] = False
+            self.prefs_["layout.css.servo.enabled"] = False # Force stylo off.
         elif engine == "chrome":
             pass
         elif engine == "webkit":

--- a/slave/configs.py
+++ b/slave/configs.py
@@ -13,13 +13,13 @@ class Default(object):
     def __init__(self, engine, shell):
         self.args_ = []
         self.env_ = {}
-        self.profile_ = ""
+        self.prefs_ = {}
         self.omit_ = False
 
         if engine == "firefox":
             self.env_["JSGC_DISABLE_POISONING"] = "1"
-            self.profile_ += "user_pref(\"dom.max_script_run_time\", 0);\n"
-            self.profile_ += "user_pref(\"javascript.options.asyncstack\", false);\n"
+            self.prefs_["dom.max_script_run_time"] = 0
+            self.prefs_["javascript.options.asyncstack"] = False
         elif engine == "chrome":
             pass
         elif engine == "webkit":
@@ -42,15 +42,15 @@ class Default(object):
     def env(self):
         return self.env_
 
-    def profile(self):
-        # Currently only for firefox profile js file.
-        return self.profile_
+    def prefs(self):
+        # Currently only for firefox profile.
+        return self.prefs_
 
 class Wasm(Default):
     def __init__(self, engine, shell):
         super(Wasm, self).__init__(engine, shell)
         if engine == "firefox":
-            self.profile_ += "user_pref(\"javascript.options.wasm\", true);\n"
+            self.prefs_["javascript.options.wasm"] = True
         elif engine == "chrome":
             self.args_ += ['--js-flags=--expose_wasm']
 
@@ -58,7 +58,7 @@ class WasmBaseline(Wasm):
     def __init__(self, engine, shell):
         super(WasmBaseline, self).__init__(engine, shell)
         if engine == "firefox":
-            self.profile_ += "user_pref(\"javascript.options.wasm_baselinejit\", true);\n"
+            self.prefs_["javascript.options.wasm_baselinejit"] = True
 
 class UnboxedObjects(Default):
     def __init__(self, engine, shell):
@@ -139,11 +139,11 @@ class NoE10S(Default):
     def __init__(self, engine, shell):
         super(NoE10S, self).__init__(engine, shell)
         if engine == "firefox" and not shell:
-            self.profile_ += "user_pref(\"browser.tabs.remote.autostart\", false);\n"
-            self.profile_ += "user_pref(\"browser.tabs.remote.autostart.1\", false);\n"
-            self.profile_ += "user_pref(\"browser.tabs.remote.autostart.2\", false);\n"
-            self.profile_ += "user_pref(\"browser.tabs.remote.autostart.3\", false);\n"
-            self.profile_ += "user_pref(\"browser.tabs.remote.autostart.4\", false);\n"
+            self.prefs_["browser.tabs.remote.autostart"] = False
+            self.prefs_["browser.tabs.remote.autostart.1"] = False
+            self.prefs_["browser.tabs.remote.autostart.2"] = False
+            self.prefs_["browser.tabs.remote.autostart.3"] = False
+            self.prefs_["browser.tabs.remote.autostart.4"] = False
         else:
             self.omit_ = True
 
@@ -151,11 +151,11 @@ class E10S(Default):
     def __init__(self, engine, shell):
         super(E10S, self).__init__(engine, shell)
         if engine == "firefox" and not shell:
-            self.profile_ += "user_pref(\"browser.tabs.remote.autostart\", true);\n"
-            self.profile_ += "user_pref(\"browser.tabs.remote.autostart.1\", true);\n"
-            self.profile_ += "user_pref(\"browser.tabs.remote.autostart.2\", true);\n"
-            self.profile_ += "user_pref(\"browser.tabs.remote.autostart.3\", true);\n"
-            self.profile_ += "user_pref(\"browser.tabs.remote.autostart.4\", true);\n"
+            self.prefs_["browser.tabs.remote.autostart"] = True
+            self.prefs_["browser.tabs.remote.autostart.1"] = True
+            self.prefs_["browser.tabs.remote.autostart.2"] = True
+            self.prefs_["browser.tabs.remote.autostart.3"] = True
+            self.prefs_["browser.tabs.remote.autostart.4"] = True
         else:
             self.omit_ = True
 

--- a/slave/executors.py
+++ b/slave/executors.py
@@ -3,6 +3,8 @@ import os
 import sys
 import time
 
+from mozprofile.profile import FirefoxProfile
+
 import utils
 import runners
 
@@ -52,7 +54,7 @@ class BrowserExecutor(object):
         env.update(self.engineInfo["env"])
         args = config.args() + self.engineInfo["args"] + [benchmark.url]
 
-        self.execute(benchmark, env, args, config.profile())
+        self.execute(benchmark, env, args, config.prefs())
 
         if not os.path.exists("results"):
             return None
@@ -85,7 +87,7 @@ class BrowserExecutor(object):
             print "TIMEOUT (executor){}".format(suite)
 
 class EdgeExecutor(BrowserExecutor):
-    def execute(self, benchmark, env, args, profile):
+    def execute(self, benchmark, env, args, prefs):
         runner = runners.getRunner(self.engineInfo["platform"], {
             "windows_processname": "cmd.exe"
         })
@@ -112,7 +114,7 @@ class EdgeExecutor(BrowserExecutor):
         runner.start("cmd.exe", ["/C", "taskkill", "/IM", "MicrosoftEdge.exe", "/F"], env)
 
 class FirefoxExecutor(BrowserExecutor):
-    def execute(self, benchmark, env, args, profile):
+    def execute(self, benchmark, env, args, prefs):
         runner = runners.getRunner(self.engineInfo["platform"], {
             "osx_mount_point": "/Volumes/Nightly",
             "osx_binary": "/Volumes/Nightly/Nightly.app/Contents/MacOS/firefox",
@@ -133,10 +135,7 @@ class FirefoxExecutor(BrowserExecutor):
         runner.rm("profile/")
 
         # create new profile
-        runner.mkdir("profile/")
-
-        # Update profile to disable slow script dialog
-        runner.write("profile/prefs.js", profile)
+        profile = FirefoxProfile(profile="profile/", preferences=prefs)
 
         self.reset_results()
 
@@ -153,7 +152,7 @@ class FirefoxExecutor(BrowserExecutor):
         runner.killall("plugin-container")
 
 class ChromeExecutor(BrowserExecutor):
-    def execute(self, benchmark, env, args, profile):
+    def execute(self, benchmark, env, args, prefs):
         runner = runners.getRunner(self.engineInfo["platform"], {
             #"osx_mount_point": "/Volumes/Nightly",
             #"osx_binary": "/Volumes/Nightly/Nightly.app/Contents/MacOS/firefox",
@@ -202,7 +201,7 @@ class ChromeExecutor(BrowserExecutor):
         runner.killAllInstances()
 
 class WebKitExecutor(BrowserExecutor):
-    def execute(self, benchmark, env, args, profile):
+    def execute(self, benchmark, env, args, prefs):
         runner = runners.getRunner(self.engineInfo["platform"], {
             "osx_mount_point": "/Volumes/WebKit",
             "osx_binary": "/Volumes/WebKit/WebKit.app/Contents/MacOS/WebKit"
@@ -234,7 +233,7 @@ class WebKitExecutor(BrowserExecutor):
         runner.killAllInstances()
 
 class ServoExecutor(BrowserExecutor):
-    def execute(self, benchmark, env, args, profile):
+    def execute(self, benchmark, env, args, prefs):
         runner = runners.getRunner(self.engineInfo["platform"], {})
 
         # kill all possible running instances.


### PR DESCRIPTION
The first commit changes from using a string of user_pref values in profile_ to keeping the preferences in a dictionary that is passed to FirefoxProfile to create the profile. See the bug for more details.

The second commit adds the preference prefs["layout.css.servo.enabled"] = False to prevent servo from running.