### PR TITLE
Support autoland in the list of Mozilla repositories;

### DIFF
--- a/slave/url_creator.py
+++ b/slave/url_creator.py
@@ -4,9 +4,6 @@ import re
 
 import utils
 
-MAC_BUILDBOT_REPOSITORIES = ('mozilla-beta', 'mozilla-release', 'mozilla-esr52')
-
-
 class UrlCreator(object):
     def __init__(self, config, repo, other_platform=None):
         self.repo = repo
@@ -141,6 +138,8 @@ class MozillaUrlCreator(UrlCreator):
     def __init__(self, config, repo, platform=None):
         if repo == "mozilla-try":
             repo = "try";
+        if repo == "mozilla-autoland":
+            repo = "autoland"
         UrlCreator.__init__(self, config, repo, platform)
 
     def _platform(self):

--- a/tests/test_url_creator.py
+++ b/tests/test_url_creator.py
@@ -15,6 +15,7 @@ PLATFORMS = [
 
 REPOS = [
     "mozilla-inbound",
+    "mozilla-autoland",
     "mozilla-central",
     "mozilla-beta",
     "mozilla-release",


### PR DESCRIPTION
It would support work being done in bug 1393068. I just tweaked the url_creator script and it happens to pass all the tests, which is awesome, thanks to @armenzg recent work. Can you have a look, please?

(cc @bclary)