### PR TITLE
Support newer treeherder-client

### DIFF
--- a/treeherder/submission.py
+++ b/treeherder/submission.py
@@ -8,7 +8,7 @@ import os
 import requests
 import socket
 import time
-from urlparse import urljoin, urlparse
+from urlparse import urljoin
 import uuid
 
 try:
@@ -148,9 +148,9 @@ class Submission(object):
             logger.info('Pretending to submit job')
             return
 
-        url = urlparse(self.url)
-        client = TreeherderClient(protocol=url.scheme, host=url.hostname,
-                                  client_id=self.client_id, secret=self.secret)
+        client = TreeherderClient(server_url=self.url,
+                                  client_id=self.client_id,
+                                  secret=self.secret)
         client.post_collection(self.repository, job_collection)
 
         logger.info('Results are available to view at: {}'.format(


### PR DESCRIPTION
**1) Stop using deprecated TreeherderClient protocol/host arguments**
They've been replaced with `server_url` instead (which should be of form `https://treeherder.mozilla.org` with no trailing slash).

**2) Use TreeherderClient's `add_revision()` instead of `add_revision_hash()`**
Since the latter has been deprecated for some time, and now removed in the latest treeherder-client release. It is no longer necessary to perform the separate lookup to map a revision to the revision hash.

Fixes #154.

----

**NB: Before deploying:**
* check that the treeherder `host` config key set in the local `awfy-server.config` file on the server is of the correct form (ie no trailing slash). 
* update to the latest treeherder-client
  - the comment in submission.py says to use `sudo` (sidenote: this is not recommended Python practice, but lets not change that for now), so I'd run `sudo pip install -U treeherder-client` on the server to upgrade.
  - note that as soon as you update, the old submission code will no longer work, so you'll need to deploy this PR asap. Ordinarily one would stagger the version updates so it was always forwards-backwards compatible, but the 2.0.1 version in use here is so old I've lost track of what change are needed when, so this is easier.