### PR TITLE
Add support for v8's liftoff

### DIFF
--- a/slave/configs.py
+++ b/slave/configs.py
@@ -52,27 +52,25 @@ class Default(object):
         # Currently only for firefox profile.
         return self.prefs_
 
-class Wasm(Default):
-    def __init__(self, engine, shell):
-        super(Wasm, self).__init__(engine, shell)
-        if engine == "firefox":
-            self.prefs_["javascript.options.wasm"] = True
-        elif engine == "chrome":
-            self.args_ += ['--js-flags=--expose_wasm']
-
-class WasmBaseline(Wasm):
+class WasmBaseline(Default):
     def __init__(self, engine, shell):
         super(WasmBaseline, self).__init__(engine, shell)
         if engine == "firefox":
             self.prefs_["javascript.options.wasm_baselinejit"] = True
             self.prefs_["javascript.options.wasm_ionjit"] = False
+        elif engine == "chrome":
+            self.args_ += ['--js-flags=--liftoff']
+        else:
+            self.omit_ = True
 
-class WasmTiering(Wasm):
+class WasmTiering(Default):
     def __init__(self, engine, shell):
         super(WasmTiering, self).__init__(engine, shell)
         if engine == "firefox":
             self.prefs_["javascript.options.wasm_baselinejit"] = True
             self.prefs_["javascript.options.wasm_ionjit"] = True
+        else:
+            self.omit_ = True
 
 class UnboxedObjects(Default):
     def __init__(self, engine, shell):
@@ -194,8 +192,6 @@ class StyloDisabled(Default):
 def getConfig(name, info):
     if name == "default":
         return Default(info["engine_type"], info["shell"])
-    if name == "wasm":
-        return Wasm(info["engine_type"], info["shell"])
     if name == "wasm-baseline":
         return WasmBaseline(info["engine_type"], info["shell"])
     if name == "wasm-tiering":

--- a/slave/execute.py
+++ b/slave/execute.py
@@ -66,13 +66,18 @@ if options.mode_rules is None:
         "firefox,branchpruning:branchpruning",
         "firefox,e10s:e10s",
         "firefox,noe10s:noe10s",
+        "firefox,wasm:jmim",
+        "firefox,wasm-baseline:wasmbaseline",
+        "firefox,wasm-tiering:wasmtiering",
         "chrome,default:v8",
         "chrome,turbofan:v8-turbofan",
         "chrome,ignition:v8-ignition",
         "chrome,turboignition:v8-turbo-ignition",
+        "chrome,wasm:v8",
+        "chrome,wasm-baseline:v8-liftoff",
         "webkit,default:jsc",
         "native,default:clang",
-        "servo,default:servo"
+        "servo,default:servo",
     ]
 
 #TODO:remove

--- a/slave/submitter.py
+++ b/slave/submitter.py
@@ -34,8 +34,7 @@ class Submitter(object):
         name = engine_type + "," + config
         if name in self.rules:
             return self.rules[name]
-        else:
-            return name
+        return name
 
     def assert_machine(self):
         if not hasattr(self, "machine"):


### PR DESCRIPTION
In addition to this, I will:

- change the control tasks in the DB so:
  1. they don't pass the `submitter-mode` flag for all the runs.
  2. they don't define the `-c wasm` since it is available by default everywhere nowadays.
- create a new DB entry in `awfy-mode` to describe the `v8-liftoff` line (choose a color, etc).

Bob, can you have a look please? Thanks!