### PR TITLE
Bug 1422887 improve log handling

### DIFF
--- a/slave/benchmarks_local.py
+++ b/slave/benchmarks_local.py
@@ -1,9 +1,7 @@
 import json
 import logging
 import os
-import socket
 import subprocess
-import sys
 import time
 
 import utils
@@ -110,7 +108,6 @@ class WebAudio(Benchmark):
 
     def process_results(self, results):
         ret = []
-        total = 0
         for item in results:
             if item['name'] == "Geometric Mean":
                 item['name'] = "__total__"
@@ -131,7 +128,6 @@ class UnityWebGL(Benchmark):
 
     def process_results(self, results):
         ret = []
-        total = 0
         for item in results:
             if item['benchmark'] == "Geometric Mean":
                 item['benchmark'] = "__total__"

--- a/slave/benchmarks_local.py
+++ b/slave/benchmarks_local.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import os
 import socket
 import subprocess
@@ -10,6 +11,7 @@ import utils
 class Benchmark:
     """ timeout is in minutes """
     def __init__(self, folder, page, timeout=2):
+        self.logger = logging.getLogger(self.__class__.__name__)
         if folder.endswith("/"):
             folder = folder[:-1]
 
@@ -45,7 +47,7 @@ class Benchmark:
             engine.kill()
 
             if timeout <= 0:
-                print "Running benchmark timed out"
+                utils.log_error(self.logger, "Running benchmark timed out")
                 continue
 
             fp = open("results", "r")
@@ -70,7 +72,7 @@ class AssortedDOM(Benchmark):
     def __init__(self):
         Benchmark.__init__(self, "misc-desktop/", "hosted/assorted/driver.html", 1)
         with utils.chdir(os.path.join(utils.config.BenchmarkPath, "misc-desktop")):
-            print subprocess.check_output(["python", "make-hosted.py"])
+            utils.log_info(self.logger, subprocess.check_output(["python", "make-hosted.py"]))
 
     @staticmethod
     def name():

--- a/slave/benchmarks_remote.py
+++ b/slave/benchmarks_remote.py
@@ -1,17 +1,14 @@
-import json
-import os
-import socket
-import subprocess
+import logging
 import sys
 import time
 
 sys.path.insert(1, '../driver')
 
-import utils
 
 class Benchmark:
     """ timeout is in minutes """
     def __init__(self, timeout=2, suite=None):
+        self.logger = logging.getLogger(self.__class__.__name__)
         self.suite = suite if suite is not None else self.name()
         self.version = self.suite + " " + self.static_version()
         self.url = 'http://' + self.suite + ".localhost:8000"
@@ -61,7 +58,6 @@ class Octane(Benchmark):
 
     @staticmethod
     def inject_data(path, data):
-        print "inject"
         if path == "/octane/index.html":
             return data.replace("</body>",
                                 "<script>"

--- a/slave/benchmarks_remote.py
+++ b/slave/benchmarks_remote.py
@@ -1,6 +1,5 @@
 import logging
 import sys
-import time
 
 sys.path.insert(1, '../driver')
 

--- a/slave/benchmarks_shell.py
+++ b/slave/benchmarks_shell.py
@@ -1,10 +1,11 @@
-import subprocess
-import socket
-import os
-import time
 import json
-import sys
+import logging
+import os
 import re
+import socket
+import subprocess
+import sys
+import time
 
 sys.path.insert(1, '../driver')
 import submitter
@@ -12,6 +13,7 @@ import utils
 
 class Benchmark(object):
     def __init__(self, folder, suite=None):
+        self.logger = logging.getLogger(self.__class__.__name__)
         if folder.endswith("/"):
             folder = folder[:-1]
 
@@ -61,7 +63,7 @@ class Octane(Benchmark):
             if name[0:5] == "Score":
                 name = "__total__"
             tests.append({ 'name': name, 'time': score})
-            print(score + '    - ' + name)
+            utils.log_info(self.logger, score + '    - ' + name)
 
         return tests
 
@@ -90,15 +92,15 @@ class SunSpiderBased(Benchmark):
             if x[0:5] == "Total":
                 m = re.search(":\s+(\d+\.\d+)ms", x)
                 tests.append({ 'name': '__total__', 'time': m.group(1)})
-                print(m.group(1) + '    - __total__')
+                utils.log_info(self.logger, m.group(1) + '    - __total__')
             elif found == True and x[0:4] == "    ":
                 m = re.search("    (.+):\s+(\d+\.\d+)ms", x)
                 if m != None:
                     tests.append({ 'name': m.group(1), 'time': m.group(2)})
-                    print(m.group(2) + '    - ' + m.group(1))
+                    utils.log_info(self.logger, m.group(2) + '    - ' + m.group(1))
 
         if found == False:
-            print(output)
+            utils.log_info(self.logger, output)
             raise Exception("output marker not found")
 
         return tests
@@ -194,7 +196,7 @@ class Dart(Benchmark):
             score = float(m.group(2))/1000
             total += score
             tests.append({ 'name': name, 'time': score})
-            print(str(score) + '    - ' + name)
+            utils.log_info(self.logger, str(score) + '    - ' + name)
         tests.append({ 'name': '__total__', 'time': total })
 
         return tests
@@ -228,9 +230,9 @@ class SixSpeed(Benchmark):
             score = m.group(2)
             total += int(score)
             tests.append({ 'name': name, 'time': score})
-            print(score + '    - ' + name)
+            utils.log_info(self.logger, score + '    - ' + name)
         tests.append({ 'name': '__total__', 'time': total})
-        print(str(total) + '    - __total__')
+        utils.log_info(self.logger, str(total) + '    - __total__')
 
         return tests
 
@@ -330,7 +332,7 @@ class WebToolingBenchmark(Benchmark):
             if name == "mean":
                 name = "__total__"
             tests.append({'name': name, 'time': score})
-            print(score + '    - ' + name)
+            utils.log_info(self.logger, score + '    - ' + name)
 
         return tests
 

--- a/slave/benchmarks_shell.py
+++ b/slave/benchmarks_shell.py
@@ -1,14 +1,9 @@
-import json
 import logging
 import os
 import re
-import socket
-import subprocess
 import sys
-import time
 
 sys.path.insert(1, '../driver')
-import submitter
 import utils
 
 class Benchmark(object):

--- a/slave/build.py
+++ b/slave/build.py
@@ -6,7 +6,6 @@ import os
 import platform
 import shutil
 import socket
-import sys
 import urllib
 
 import utils

--- a/slave/configs.py
+++ b/slave/configs.py
@@ -1,8 +1,6 @@
-import os
 import sys
 
 sys.path.insert(1, '../driver')
-import utils
 
 #TODO: move into builder
 #with utils.chdir(os.path.join(utils.config.RepoPath, self.source)):

--- a/slave/download.py
+++ b/slave/download.py
@@ -11,7 +11,6 @@ import sys
 import tarfile
 import urllib
 import urllib2
-import zipfile
 
 from optparse import OptionParser
 

--- a/slave/execute.py
+++ b/slave/execute.py
@@ -129,6 +129,8 @@ class AutoSpawnServer:
             self.server = None
 
 if __name__ == '__main__':
+    logger = utils.create_logger()
+
     utils.log_banner("EXECUTE")
     log = utils.make_log('EXECUTE')
 
@@ -160,6 +162,7 @@ if __name__ == '__main__':
                         log('Exception: ' +  repr(e))
                         import traceback
                         traceback.print_exc()
+                        utils.log_exception(logger, 'Exception')
                         continue
 
                     mode = submitter.mode(info["engine_type"], config_name)

--- a/slave/executors.py
+++ b/slave/executors.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import os
 import sys
 import time
@@ -10,6 +11,7 @@ import runners
 
 class ShellExecutor(object):
     def __init__(self, engineInfo):
+        self.logger = logging.getLogger(self.__class__.__name__)
         self.engineInfo = engineInfo
 
     def run(self, benchmark, config):
@@ -43,6 +45,7 @@ class ShellExecutor(object):
 
 class BrowserExecutor(object):
     def __init__(self, engineInfo):
+        self.logger = logging.getLogger(self.__class__.__name__)
         self.engineInfo = engineInfo
         self.benchmark = None
 
@@ -84,7 +87,7 @@ class BrowserExecutor(object):
                 suite = " when running {}".format(self.benchmark.suite)
             except:
                 pass
-            print "TIMEOUT (executor){}".format(suite)
+            utils.log_error(self.logger, "TIMEOUT (executor) {}".format(suite))
 
 class EdgeExecutor(BrowserExecutor):
     def execute(self, benchmark, env, args, prefs):
@@ -93,7 +96,7 @@ class EdgeExecutor(BrowserExecutor):
         })
 
         # kill browser
-        print "Killing Edge (before)..."
+        utils.log_info(self.logger, "Killing Edge (before)...")
         process = runner.start("cmd.exe", ["/C", "taskkill", "/IM", "MicrosoftEdge.exe", "/F"], env)
         process.wait()
 
@@ -110,7 +113,7 @@ class EdgeExecutor(BrowserExecutor):
         self.wait_for_results(benchmark.timeout)
 
         # kill browser
-        print "Killing Edge (after)..."
+        utils.log_info(self.logger, "Killing Edge (after)...")
         runner.start("cmd.exe", ["/C", "taskkill", "/IM", "MicrosoftEdge.exe", "/F"], env)
 
 class FirefoxExecutor(BrowserExecutor):
@@ -124,7 +127,7 @@ class FirefoxExecutor(BrowserExecutor):
         })
 
         # kill all possible running instances.
-        print "Killing Firefox (before)..."
+        utils.log_info(self.logger, "Killing Firefox (before)...")
         runner.killAllInstances()
         runner.killall("plugin-container")
 
@@ -146,7 +149,7 @@ class FirefoxExecutor(BrowserExecutor):
         self.wait_for_results(benchmark.timeout)
 
         # kill browser
-        print "Killing Firefox (after)..."
+        utils.log_info(self.logger, "Killing Firefox (after)...")
         runner.kill(process)
         runner.killAllInstances()
         runner.killall("plugin-container")
@@ -163,7 +166,7 @@ class ChromeExecutor(BrowserExecutor):
         })
 
         # kill all possible running instances.
-        print "Killing Chrome (before)..."
+        utils.log_info(self.logger, "Killing Chrome (before)...")
         runner.killAllInstances()
 
         # if needed install the executable
@@ -196,7 +199,7 @@ class ChromeExecutor(BrowserExecutor):
         self.wait_for_results(benchmark.timeout)
 
         # kill browser
-        print "Killing Chrome (after)..."
+        utils.log_info(self.logger, "Killing Chrome (after)...")
         runner.kill(process)
         runner.killAllInstances()
 
@@ -210,7 +213,7 @@ class WebKitExecutor(BrowserExecutor):
         })
 
         # kill all possible running instances.
-        print "Killing Webkit (before)..."
+        utils.log_info(self.logger, "Killing Webkit (before)...")
         runner.killAllInstances()
 
         # remove the saved tabs.
@@ -228,7 +231,7 @@ class WebKitExecutor(BrowserExecutor):
         self.wait_for_results(benchmark.timeout)
 
         # kill browser
-        print "Killing Webkit (after)..."
+        utils.log_info(self.logger, "Killing Webkit (after)...")
         runner.kill(process)
         runner.killAllInstances()
 
@@ -237,7 +240,7 @@ class ServoExecutor(BrowserExecutor):
         runner = runners.getRunner(self.engineInfo["platform"], {})
 
         # kill all possible running instances.
-        print "Killing Servo (before)..."
+        utils.log_info(self.logger, "Killing Servo (before)...")
         runner.killall("servo")
 
         self.reset_results()
@@ -249,7 +252,7 @@ class ServoExecutor(BrowserExecutor):
         self.wait_for_results(benchmark.timeout)
 
         # kill browser
-        print "Killing Servo (after)..."
+        utils.log_info(self.logger, "Killing Servo (after)...")
         runner.kill(process)
 
 def make_executor(engineInfo):

--- a/slave/executors.py
+++ b/slave/executors.py
@@ -1,7 +1,6 @@
 import json
 import logging
 import os
-import sys
 import time
 
 from mozprofile.profile import FirefoxProfile

--- a/slave/puller.py
+++ b/slave/puller.py
@@ -1,11 +1,14 @@
-import re
+import logging
 import os
+import re
 import shutil
 
+import utils
 from utils import Run, chdir
 
 class Puller(object):
     def __init__(self, repo, folder):
+        self.logger = logging.getLogger(self.__class__.__name__)
         self.repo = repo
         self.folder = folder
 
@@ -55,6 +58,9 @@ class HG(Puller):
 
 class SVN(Puller):
 
+    def __init__(self, repo, folder):
+        super(SVN, self).__init__(repo, folder)
+
     def clone(self):
         Run(['svn', 'co', self.repo, self.folder])
 
@@ -64,8 +70,8 @@ class SVN(Puller):
                 output = Run(['svn', 'info'])
             except:
                 return False
-            print self.repo
-            print output
+            utils.log_info(self.logger, self.repo)
+            utils.log_info(self.logger, output)
             if "URL: "+self.repo in output:
                 return True
             exit()

--- a/slave/puller.py
+++ b/slave/puller.py
@@ -155,7 +155,6 @@ class V8GIT(GIT):
         with chdir(self.path()):
             Run(['git', 'pull', 'origin', 'master'])
 
-        env = os.environ.copy()
         with chdir(self.path()):
             Run(['gclient', 'sync'], self.make_env())
 

--- a/slave/run-task.sh
+++ b/slave/run-task.sh
@@ -1,25 +1,64 @@
 #!/bin/bash
 
-if [ -f /tmp/awfy-deamon ]
-then
-    echo "Already running";
-    exit;
+# Execute the arewefastyet task for the control unit
+# specified in the environment variable CONTROL_UNIT_ID.
+
+help()
+{
+    cat <<EOF
+error: Missing CONTROL_UNIT_ID environment variable.
+
+Either specify CONTROL_UNIT_ID in the environment or create
+~/AWFY_CONFIG containing the line:
+
+export CONTROL_UNIT_ID=id
+
+where id is the control unit id for this host.
+
+Then re-run this command.
+EOF
+}
+
+if [[ -e ~/AWFY_CONFIG ]]; then
+    source ~/AWFY_CONFIG
 fi
 
-touch /tmp/awfy-deamon;
+if [[ -z "$CONTROL_UNIT_ID" ]]; then
+    help
+    exit 1
+fi
+
+if pgrep -f run-task.sh; then
+    echo "run-task.sh is already running."
+    exit 2
+fi
 
 control_c()
 {
-    rm /tmp/awfy-deamon;
-    exit;
+    local answer
+    read -e -i Y -p "Kill running task?: Y/N" answer
+    if [[ "$answer" == "Y" ]]; then
+        pkill -9 -f task.py
+    fi
+    echo "Exiting...."
+    exit 2
 }
 
 # trap keyboard interrupt (control-c)
 trap control_c SIGINT
 
-cd arewefastyet
+export DISPLAY=:0
 
-for (( ; ; ))
-do
-    python task.py --run <<CONTROL_UNIT_ID>>
+cd ~/arewefastyet/slave
+
+while true; do
+    # Remove temporary files left behind by Firefox.
+    rm -f /tmp/tmpaddon*
+    echo "$(date): task.py --run $CONTROL_UNIT_ID"
+    if ! python task.py --run $CONTROL_UNIT_ID; then
+        echo "$(date): task.py --run $CONTROL_UNIT_ID: $?"
+    fi
+    echo "$(date): sleep 60"
+    echo "========================================"
+    sleep 60
 done

--- a/slave/runners.py
+++ b/slave/runners.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import shutil
+import signal
 import stat
 import subprocess
 import time
@@ -84,8 +85,8 @@ class Runner(object):
 
     def find(self, path, file):
         paths = subprocess.check_output(["find", path])
-        paths = [path.rstrip() for path in paths.splitlines()]
-        return [path for path in paths if path.endswith(file)]
+        paths = [p.rstrip() for p in paths.splitlines()]
+        return [p for p in paths if p.endswith(file)]
 
     def put(self, path, recursive=True):
         return path
@@ -117,7 +118,7 @@ class LinuxRunner(Runner):
     def install(self, exe):
         path = os.path.dirname(exe)
         paths = subprocess.check_output(["find", path])
-        paths = [path.rstrip() for path in paths.splitlines()]
+        paths = [p.rstrip() for p in paths.splitlines()]
 
         utils.log_info(self.logger, "Setting executable bit for {} and children.".format(path))
         for path in paths:
@@ -142,7 +143,7 @@ class WindowsRunner(LinuxRunner):
     def install(self, exe):
         path = os.path.dirname(exe)
         paths = subprocess.check_output(["find", path])
-        paths = [path.rstrip() for path in paths.splitlines()]
+        paths = [p.rstrip() for p in paths.splitlines()]
 
         utils.log_info(self.logger, "Setting executable bit for {} and children.".format(path))
         for path in paths:
@@ -187,7 +188,7 @@ class OSXRunner(Runner):
         else:
             path = os.path.dirname(exe)
             paths = subprocess.check_output(["find", path])
-            paths = [path.rstrip() for path in paths.splitlines()]
+            paths = [p.rstrip() for p in paths.splitlines()]
 
             utils.log_info(self.logger, "Setting executable bit for {} and children.".format(path))
             for path in paths:

--- a/slave/server.py
+++ b/slave/server.py
@@ -1,18 +1,12 @@
 import BaseHTTPServer
 import hashlib
-import httplib
-import json
 import os
 import pickle
 import requests
 import signal
-import sys
-import urllib
 import urlparse
 
 from SimpleHTTPServer import SimpleHTTPRequestHandler
-
-import benchmarks_remote as benchmarks
 
 import utils
 utils.config.init("awfy.config")

--- a/slave/submitter.py
+++ b/slave/submitter.py
@@ -3,18 +3,20 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import contextlib
+import json
+import logging
 import os
 import re
 import urllib
 import urllib2
-import json
-import contextlib
 
 import utils
 
 class Submitter(object):
 
     def __init__(self):
+        self.logger = logging.getLogger(self.__class__.__name__)
         self.urls = utils.config.get('main', 'updateURL').split(",")
         self.runIds = []
         for i in range(len(self.urls)):
@@ -38,7 +40,7 @@ class Submitter(object):
 
     def assert_machine(self):
         if not hasattr(self, "machine"):
-            print "please provide the machine number for submitting (--submitter-machine)"
+            utils.log_error(self.logger, "please provide the machine number for submitting (--submitter-machine)")
             exit()
 
     def set_machine(self, machine):
@@ -173,9 +175,11 @@ class RemoteSubmitter(Submitter):
 
 class PrintSubmitter(Submitter):
     def __init__(self):
+        super(Submitter, self).__init__()
         self.msg = ''
 
     def log(self, msg):
+        utils.log_info(self.logger, msg)
         self.msg += msg + '\n'
         print msg
 
@@ -198,8 +202,8 @@ class PrintSubmitter(Submitter):
         self.log("%s (%s -- %s): %s" % (name, suiteversion, mode, str(time)))
 
     def finish(self, status = 1):
-        print "\n*******************************************\nSummary: "
-        print self.msg
+        utils.log_info(self.logger, "\n*******************************************\nSummary: ")
+        utils.log_info(self.logger, self.msg)
         self.msg = ''
 
 def get_submitter(name):
@@ -211,6 +215,8 @@ def get_submitter(name):
         raise Exception('unknown submitter!')
 
 if __name__ == "__main__":
+    logger = utils.create_logger()
+
     from optparse import OptionParser
     parser = OptionParser(usage="usage: %prog [options]")
 

--- a/slave/task.py
+++ b/slave/task.py
@@ -1,12 +1,17 @@
-import os
-import urllib2
-import urllib
-from optparse import OptionParser
 import json
+import sys
+import urllib
+import urllib2
+
+from optparse import OptionParser
+
 import utils
 
 if __name__ == "__main__":
-    from optparse import OptionParser
+    logger = utils.create_logger(maxBytes=sys.maxint,
+                                 backupCount=3,
+                                 rollover=True)
+
     parser = OptionParser(usage="usage: %prog [options]")
 
     parser.add_option("-r", "--run", dest="machine", type="int", help="Get and run the task of a given (control) machine.")

--- a/slave/url_creator.py
+++ b/slave/url_creator.py
@@ -1,3 +1,4 @@
+import logging
 import platform
 import urllib2
 import re
@@ -62,6 +63,7 @@ class TaskClusterIndexHelper(object):
     _index_url = 'https://index.taskcluster.net/v1/task/gecko.v2'
     _artifacts = 'https://public-artifacts.taskcluster.net'
     _task_inspector = 'https://tools.taskcluster.net/tasks'
+    _logger = logging.getLogger('TaskClusterIndexHelper')
 
     BUILDTYPES = ('debug', 'nightly', 'opt', 'pgo')
     PRODUCTS = ('firefox', 'mobile')
@@ -70,7 +72,7 @@ class TaskClusterIndexHelper(object):
     @classmethod
     def build_url(cls, repo_name, product, platform, buildtype, revision=None):
         task_id = cls._task_id(repo_name, product, platform, buildtype, revision)
-        print 'TASK: %s/%s' % (cls._task_inspector, task_id)
+        utils.log_info(cls._logger, 'TASK: %s/%s' % (cls._task_inspector, task_id))
         return cls._artifact_url(
             task_id,
             artifact_path='public/build/{}'.format(cls._artifact_to_filename(platform)))
@@ -129,7 +131,7 @@ class TaskClusterIndexHelper(object):
             task_id,
             run_id,
             artifact_path)
-        print 'URL: %s' % url
+        utils.log_info(cls._logger, 'URL: %s' % url)
         return url
 
 


### PR DESCRIPTION
Change slave/run-task.sh to the standard run script. This will require:

- either ~/AWFY_CONFIG containing export CONTROL_UNIT_ID=id or
  CONTROL_UNIT_ID already in the environment.

- arewefastyet checked out to ~/arewefastyet

Once these conditions are met, start the script via

~/arewefastyet/slave/run-task.sh

Second, we change the print statements currently used to log to
stdout to use a set of functions which will continue to print to
stdout but also will log to a rotating log file controlled by the
main process. This log file will be shared by the main and child
processes but only the main process in task.py will be able to
rotate the log.

Lastly, we fix a number of pyflakes warnings though not all.
